### PR TITLE
chore: add check meta-task for org consistency

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -21,3 +21,8 @@ echo "All scripts passed syntax check."
 [tasks.lint-formula]
 description = "Lint Homebrew formula with rubocop"
 run = "rubocop Formula/*.rb --config .rubocop.yml"
+
+[tasks.check]
+description = "Run all checks (lint + test)"
+depends = ["lint", "test"]
+run = "echo 'All checks passed'"


### PR DESCRIPTION
## Summary
- Adds a `check` meta-task to `mise.toml` that runs `lint` + `test`
- Part of org-wide mise standardization across nsheaps repos

## Test plan
- [ ] Run `mise run check` and verify it executes both lint and test tasks
- [ ] Verify `mise tasks` lists the new check task

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>