### PR TITLE
feat: update installed plugins during startup update check

### DIFF
--- a/bin/run-claude
+++ b/bin/run-claude
@@ -46,6 +46,18 @@ EOF
   fi
 fi
 
+# Update installed Claude Code plugins
+INSTALLED_PLUGINS_FILE="${CLAUDE_HOME:-$HOME/.claude}/plugins/installed_plugins.json"
+if [[ -f "$INSTALLED_PLUGINS_FILE" ]] && command -v jq &>/dev/null; then
+  PLUGIN_NAMES="$(jq -r '.plugins | keys[]' "$INSTALLED_PLUGINS_FILE" 2>/dev/null)"
+  if [[ -n "$PLUGIN_NAMES" ]]; then
+    echo "Checking for plugin updates..."
+    while IFS= read -r plugin; do
+      command claude plugin update "$plugin" 2>/dev/null || true
+    done <<< "$PLUGIN_NAMES"
+  fi
+fi
+
 claude_check_settings_backup
 
 trap claude_check_settings_backup EXIT


### PR DESCRIPTION
## Summary

- When `run-claude` checks for brew formula updates at startup, it now also iterates through installed Claude Code plugins and runs `claude plugin update` for each
- Reads plugin list from `~/.claude/plugins/installed_plugins.json` using `jq`
- Gracefully skips if `jq` is not available or no plugins are installed
- Each plugin update failure is silently ignored to avoid blocking startup

## Test plan

- [ ] Verify `run-claude` starts correctly with plugins installed
- [ ] Verify `run-claude` starts correctly when `jq` is not installed (graceful skip)
- [ ] Verify `run-claude` starts correctly when no plugins are installed
- [ ] Verify plugin update output appears after brew update check

🤖 Generated with [Claude Code](https://claude.com/claude-code)