### PR TITLE
ci: add ShellCheck, shfmt, and editorconfig-checker

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.json]
+insert_final_newline = ignore
+
+[Makefile]
+indent_style = tab
+
+# Shell scripts — shfmt reads these properties
+[*.sh]
+switch_case_indent = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,57 @@
+name: check
+
+on:
+  push:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Find bash scripts
+        id: find-bash
+        run: |
+          bash_files=""
+          # .sh files with bash shebangs
+          for f in $(find . -name '*.sh' -not -path './.git/*' -not -path './node_modules/*'); do
+            shebang=$(head -1 "$f")
+            if echo "$shebang" | grep -qE '(bash|^#!/bin/sh)'; then
+              bash_files="$bash_files $f"
+            fi
+          done
+          # bin/ scripts without .sh extension
+          for f in $(find ./bin -maxdepth 1 -type f -not -name '*.sh' -not -path './.git/*'); do
+            shebang=$(head -1 "$f")
+            if echo "$shebang" | grep -qE '(bash|^#!/bin/sh)'; then
+              bash_files="$bash_files $f"
+            fi
+          done
+          echo "files=$bash_files" >> "$GITHUB_OUTPUT"
+          echo "Found bash files:$bash_files"
+
+      - name: ShellCheck
+        if: steps.find-bash.outputs.files != ''
+        run: |
+          bash_files="${{ steps.find-bash.outputs.files }}"
+          echo "Running ShellCheck on:$bash_files"
+          shellcheck $bash_files
+
+      - name: shfmt check
+        if: steps.find-bash.outputs.files != ''
+        run: |
+          bash_files="${{ steps.find-bash.outputs.files }}"
+          echo "Running shfmt on:$bash_files"
+          # -d shows diff; indent settings sourced from .editorconfig
+          shfmt -d $bash_files
+
+      - name: EditorConfig check
+        uses: editorconfig-checker/action-editorconfig-checker@main
+
+      - name: Run editorconfig-checker
+        run: editorconfig-checker

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,11 @@
+# ShellCheck configuration for nsheaps/claude-utils
+# https://www.shellcheck.net/wiki/
+
+# Default shell dialect — all scripts in this repo are bash.
+shell=bash
+
+# SC1091: Not following sourced files — sourced paths are dynamic ($SCRIPT_DIR)
+disable=SC1091
+
+# SC2034: Variable appears unused — many variables are exported or used by sourcing scripts
+disable=SC2034

--- a/bin/cc-newsession
+++ b/bin/cc-newsession
@@ -25,9 +25,15 @@ CLAUDE_ARGS=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --temp)    IS_TEMP=true; shift ;;
-    -h|--help) show_help ;;
-    *)         CLAUDE_ARGS+=("$1"); shift ;;
+  --temp)
+    IS_TEMP=true
+    shift
+    ;;
+  -h | --help) show_help ;;
+  *)
+    CLAUDE_ARGS+=("$1")
+    shift
+    ;;
   esac
 done
 
@@ -55,7 +61,8 @@ else
   TEMP_NOTE="This workspace persists after you exit - it will NOT be automatically deleted."
 fi
 
-SYSTEM_PROMPT="$(cat << EOPROMPT
+SYSTEM_PROMPT="$(
+  cat <<EOPROMPT
 The user has launched you in an ephemeral workspace located at $WS_DIR.
 $TEMP_NOTE
 

--- a/bin/cc-resume
+++ b/bin/cc-resume
@@ -21,7 +21,7 @@ EOF
 
 for arg in "$@"; do
   case "$arg" in
-    -h|--help) show_help ;;
+  -h | --help) show_help ;;
   esac
 done
 
@@ -58,8 +58,14 @@ if [[ ${#OPTIONS[@]} -eq 0 ]]; then
   printf "Choice [1-2]: "
   read -r choice
   case "$choice" in
-    1) "$SCRIPT_DIR/run-claude" --resume "$@"; exit ;;
-    *) echo "Cancelled."; exit 0 ;;
+  1)
+    "$SCRIPT_DIR/run-claude" --resume "$@"
+    exit
+    ;;
+  *)
+    echo "Cancelled."
+    exit 0
+    ;;
   esac
 fi
 

--- a/bin/cc-tmp
+++ b/bin/cc-tmp
@@ -23,7 +23,7 @@ EOF
 # Parse for help only, pass everything else to claude
 for arg in "$@"; do
   case "$arg" in
-    -h|--help) show_help ;;
+  -h | --help) show_help ;;
   esac
 done
 
@@ -32,7 +32,8 @@ WS_DIR="/tmp/claude-workspace-$NOW"
 
 mkdir -p "$WS_DIR"
 
-SYSTEM_PROMPT="$(cat << EOPROMPT
+SYSTEM_PROMPT="$(
+  cat <<EOPROMPT
 The user has launched you in an ephemeral workspace located at $WS_DIR.
 
 This workspace persists after you exit - it will NOT be automatically deleted.

--- a/bin/ccc
+++ b/bin/ccc
@@ -18,7 +18,7 @@ EOF
 
 for arg in "$@"; do
   case "$arg" in
-    -h|--help) show_help ;;
+  -h | --help) show_help ;;
   esac
 done
 

--- a/bin/cccontinue
+++ b/bin/cccontinue
@@ -18,7 +18,7 @@ EOF
 
 for arg in "$@"; do
   case "$arg" in
-    -h|--help) show_help ;;
+  -h | --help) show_help ;;
   esac
 done
 

--- a/bin/ccr
+++ b/bin/ccr
@@ -18,7 +18,7 @@ EOF
 
 for arg in "$@"; do
   case "$arg" in
-    -h|--help) show_help ;;
+  -h | --help) show_help ;;
   esac
 done
 

--- a/bin/ccresume
+++ b/bin/ccresume
@@ -18,7 +18,7 @@ EOF
 
 for arg in "$@"; do
   case "$arg" in
-    -h|--help) show_help ;;
+  -h | --help) show_help ;;
   esac
 done
 

--- a/bin/claude-clean-orphaned
+++ b/bin/claude-clean-orphaned
@@ -20,9 +20,15 @@ FORCE=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --force)   FORCE=true; shift ;;
-    -h|--help) show_help ;;
-    *)         echo "Unknown option: $1" >&2; show_help ;;
+  --force)
+    FORCE=true
+    shift
+    ;;
+  -h | --help) show_help ;;
+  *)
+    echo "Unknown option: $1" >&2
+    show_help
+    ;;
   esac
 done
 
@@ -41,7 +47,7 @@ while IFS= read -r pid; do
   # Check ancestry for happy processes
   DOMINATED_BY_HAPPY=false
   P=$pid
-  while (( P > 1 )); do
+  while ((P > 1)); do
     PINFO=$(ps -o ppid=,comm= -p "$P" 2>/dev/null || true)
     [[ -z "$PINFO" ]] && break
     PP=${PINFO%% *}

--- a/bin/claude-diagnostics
+++ b/bin/claude-diagnostics
@@ -32,16 +32,43 @@ show_help() {
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    -v|--verbose)  VERBOSE=true; shift ;;
-    --no-archive)  NO_ARCHIVE=true; shift ;;
-    --no-user)     NO_USER=true; shift ;;
-    --no-project)  NO_PROJECT=true; shift ;;
-    --no-rules)    NO_RULES=true; shift ;;
-    --no-agents)   NO_AGENTS=true; shift ;;
-    --no-commands) NO_COMMANDS=true; shift ;;
-    --no-settings) NO_SETTINGS=true; shift ;;
-    -h|--help)     show_help ;;
-    *)             echo "Unknown option: $1" >&2; show_help ;;
+  -v | --verbose)
+    VERBOSE=true
+    shift
+    ;;
+  --no-archive)
+    NO_ARCHIVE=true
+    shift
+    ;;
+  --no-user)
+    NO_USER=true
+    shift
+    ;;
+  --no-project)
+    NO_PROJECT=true
+    shift
+    ;;
+  --no-rules)
+    NO_RULES=true
+    shift
+    ;;
+  --no-agents)
+    NO_AGENTS=true
+    shift
+    ;;
+  --no-commands)
+    NO_COMMANDS=true
+    shift
+    ;;
+  --no-settings)
+    NO_SETTINGS=true
+    shift
+    ;;
+  -h | --help) show_help ;;
+  *)
+    echo "Unknown option: $1" >&2
+    show_help
+    ;;
   esac
 done
 
@@ -50,15 +77,15 @@ DIAG_DIR=$(mktemp -d)
 TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 # Gather Claude Code stream output
-STREAM_OUTPUT=$(echo '{"type":"user","message":{"role":"user","content":"/context"},"session_id":"default","parent_tool_use_id":null}' \
-  | claude -p --input-format stream-json --output-format stream-json 2>&1)
+STREAM_OUTPUT=$(echo '{"type":"user","message":{"role":"user","content":"/context"},"session_id":"default","parent_tool_use_id":null}' |
+  claude -p --input-format stream-json --output-format stream-json 2>&1)
 
 # Extract init message (type=system, subtype=init)
 INIT_JSON=$(echo "$STREAM_OUTPUT" | jq -c 'select(.type=="system" and .subtype=="init")' | head -1)
 
 # Extract context output from user message
-CONTEXT_OUTPUT=$(echo "$STREAM_OUTPUT" | grep '"type":"user"' | jq -r '.message.content' \
-  | sed 's/<local-command-stdout>//g' | sed 's/<\/local-command-stdout>//g' 2>/dev/null || echo "(failed to parse)")
+CONTEXT_OUTPUT=$(echo "$STREAM_OUTPUT" | grep '"type":"user"' | jq -r '.message.content' |
+  sed 's/<local-command-stdout>//g' | sed 's/<\/local-command-stdout>//g' 2>/dev/null || echo "(failed to parse)")
 
 # Generate diagnostics report
 generate_report() {
@@ -120,10 +147,10 @@ if [[ "$VERBOSE" == "true" ]]; then
 fi
 
 # Save report to temp directory
-echo "$REPORT" > "$DIAG_DIR/diagnostics.md"
+echo "$REPORT" >"$DIAG_DIR/diagnostics.md"
 
 # Save raw init JSON for debugging
-echo "$INIT_JSON" | jq '.' > "$DIAG_DIR/init.json" 2>/dev/null || echo "{}" > "$DIAG_DIR/init.json"
+echo "$INIT_JSON" | jq '.' >"$DIAG_DIR/init.json" 2>/dev/null || echo "{}" >"$DIAG_DIR/init.json"
 
 # Copy config files (with error handling for missing files)
 copy_if_exists() {
@@ -212,7 +239,7 @@ if [[ "$NO_PROJECT" != "true" ]]; then
 fi
 
 # Create manifest of what was collected
-find "$DIAG_DIR" -type f | sed "s|$DIAG_DIR/||" | sort > "$DIAG_DIR/manifest.txt"
+find "$DIAG_DIR" -type f | sed "s|$DIAG_DIR/||" | sort >"$DIAG_DIR/manifest.txt"
 
 # Count files by category
 count_files() {

--- a/bin/claude-simple-cli
+++ b/bin/claude-simple-cli
@@ -37,15 +37,39 @@ show_help() {
 # Parse arguments
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --resume)       RESUME_ID="$2"; shift 2 ;;
-    --fork-session) FORK_SESSION="true"; shift ;;
-    --json)         OUTPUT_JSON="true"; shift ;;
-    --no-stream)    NO_STREAM="true"; shift ;;
-    --model)        MODEL="$2"; shift 2 ;;
-    -p|--print)     PRINT_MODE="true"; shift ;;
-    -h|--help)      show_help ;;
-    -*)             echo "Unknown option: $1" >&2; show_help ;;
-    *)              PROMPT="$1"; shift ;;
+  --resume)
+    RESUME_ID="$2"
+    shift 2
+    ;;
+  --fork-session)
+    FORK_SESSION="true"
+    shift
+    ;;
+  --json)
+    OUTPUT_JSON="true"
+    shift
+    ;;
+  --no-stream)
+    NO_STREAM="true"
+    shift
+    ;;
+  --model)
+    MODEL="$2"
+    shift 2
+    ;;
+  -p | --print)
+    PRINT_MODE="true"
+    shift
+    ;;
+  -h | --help) show_help ;;
+  -*)
+    echo "Unknown option: $1" >&2
+    show_help
+    ;;
+  *)
+    PROMPT="$1"
+    shift
+    ;;
   esac
 done
 

--- a/bin/claude-team
+++ b/bin/claude-team
@@ -70,32 +70,32 @@ CLAUDE_ARGS=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    -m|--mode)
-      if [[ -z "${2:-}" ]]; then
-        fatal "--mode requires a value: auto, in-process, or tmux"
-      fi
-      case "$2" in
-        auto|in-process|tmux) TEAMMATE_MODE="$2" ;;
-        *) fatal "Invalid mode '$2'. Must be: auto, in-process, or tmux" ;;
-      esac
-      shift 2
-      ;;
-    --no-interactive)
-      INTERACTIVE=false
-      shift
-      ;;
-    -h|--help)
-      show_help
-      ;;
-    --)
-      shift
-      CLAUDE_ARGS+=("$@")
-      break
-      ;;
-    *)
-      CLAUDE_ARGS+=("$1")
-      shift
-      ;;
+  -m | --mode)
+    if [[ -z "${2:-}" ]]; then
+      fatal "--mode requires a value: auto, in-process, or tmux"
+    fi
+    case "$2" in
+    auto | in-process | tmux) TEAMMATE_MODE="$2" ;;
+    *) fatal "Invalid mode '$2'. Must be: auto, in-process, or tmux" ;;
+    esac
+    shift 2
+    ;;
+  --no-interactive)
+    INTERACTIVE=false
+    shift
+    ;;
+  -h | --help)
+    show_help
+    ;;
+  --)
+    shift
+    CLAUDE_ARGS+=("$@")
+    break
+    ;;
+  *)
+    CLAUDE_ARGS+=("$1")
+    shift
+    ;;
   esac
 done
 

--- a/bin/claude-update
+++ b/bin/claude-update
@@ -16,7 +16,7 @@ show_help() {
 
 for arg in "$@"; do
   case "$arg" in
-    -h|--help) show_help ;;
+  -h | --help) show_help ;;
   esac
 done
 

--- a/bin/claude-utils
+++ b/bin/claude-utils
@@ -50,11 +50,11 @@ EOF
 }
 
 case "${1:-}" in
-  -v|--version) show_version ;;
-  -h|--help|"") show_help ;;
-  *)
-    echo "Unknown option: $1" >&2
-    echo "Run 'claude-utils --help' for usage." >&2
-    exit 1
-    ;;
+-v | --version) show_version ;;
+-h | --help | "") show_help ;;
+*)
+  echo "Unknown option: $1" >&2
+  echo "Run 'claude-utils --help' for usage." >&2
+  exit 1
+  ;;
 esac

--- a/bin/ct
+++ b/bin/ct
@@ -27,7 +27,7 @@ EOF
 
 for arg in "$@"; do
   case "$arg" in
-    -h|--help) show_help ;;
+  -h | --help) show_help ;;
   esac
 done
 

--- a/bin/lib/claude.lib.sh
+++ b/bin/lib/claude.lib.sh
@@ -59,7 +59,7 @@ _claudeish() {
   fi
 
   # Fall back to claude if happy is not installed
-  if [[ "$BIN_NAME" == "happy" ]] && ! command -v happy &> /dev/null; then
+  if [[ "$BIN_NAME" == "happy" ]] && ! command -v happy &>/dev/null; then
     echo "happy CLI not found. Install via \`npm install -g happy-coder\`" >&2
     echo "  see: https://happy.engineering/docs/quick-start/" >&2
     echo "Falling back to 'claude'." >&2

--- a/bin/lib/stdlib.sh
+++ b/bin/lib/stdlib.sh
@@ -85,7 +85,6 @@ info() {
   echo -e "${ANSI_BLUE}[INFO]${ANSI_RESET} $1"
 }
 
-
 # dryrun() prints a dry-run message with [DRY] prefix
 dryrun() {
   echo -e "${ANSI_YELLOW}[DRY]${ANSI_RESET} $1"
@@ -317,7 +316,7 @@ realpath.absolute() {
       REPLY="${REPLY%/}/$1"
       shift
       ;;
-    esac done
+  esac done
   ${eg:+shopt -u $eg}
 }
 # ---

--- a/bin/run-claude
+++ b/bin/run-claude
@@ -29,14 +29,14 @@ show_help() {
 
 for arg in "$@"; do
   case "$arg" in
-    -h|--help) show_help ;;
+  -h | --help) show_help ;;
   esac
 done
 
 CHECK_FOR_UPDATES_ON_FORMULAE=("claude-code" "claude-utils")
-AVAILABLE_UPDATES="$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --verbose "${CHECK_FOR_UPDATES_ON_FORMULAE[@]}" || true )"
+AVAILABLE_UPDATES="$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --verbose "${CHECK_FOR_UPDATES_ON_FORMULAE[@]}" || true)"
 if [[ -n "$AVAILABLE_UPDATES" ]]; then
-  cat << EOF
+  cat <<EOF
 Updates are available for the following formulae:"
 $(echo "$AVAILABLE_UPDATES" | xargs -I{} echo " - local {} remote")
 

--- a/mise.toml
+++ b/mise.toml
@@ -7,22 +7,79 @@ description = "Run CLI tests"
 run = "bash test/cli-test.sh"
 
 [tasks.lint]
-description = "Check bash syntax for all scripts"
+description = "Run ShellCheck on all bash scripts"
 run = """
-find bin -type f -name '*.sh' -o -type f ! -name '*.*' | while read -r script; do
-  if head -1 "$script" | grep -q 'bash'; then
-    echo "Checking $script..."
-    bash -n "$script"
+bash_files=""
+for f in $(find bin -type f -name '*.sh' -o -type f ! -name '*.*'); do
+  if head -1 "$f" | grep -q 'bash'; then
+    bash_files="$bash_files $f"
   fi
 done
-echo "All scripts passed syntax check."
+for f in $(find bin/lib -type f -name '*.sh' 2>/dev/null); do
+  if head -1 "$f" | grep -q 'bash'; then
+    bash_files="$bash_files $f"
+  fi
+done
+for f in $(find test -type f -name '*.sh' 2>/dev/null); do
+  if head -1 "$f" | grep -q 'bash'; then
+    bash_files="$bash_files $f"
+  fi
+done
+echo "Checking:$bash_files"
+shellcheck $bash_files
 """
 
 [tasks.lint-formula]
 description = "Lint Homebrew formula with rubocop"
 run = "rubocop Formula/*.rb --config .rubocop.yml"
 
+[tasks.fmt]
+description = "Format all bash scripts with shfmt"
+run = """
+bash_files=""
+for f in $(find bin -type f -name '*.sh' -o -type f ! -name '*.*'); do
+  if head -1 "$f" | grep -q 'bash'; then
+    bash_files="$bash_files $f"
+  fi
+done
+for f in $(find bin/lib -type f -name '*.sh' 2>/dev/null); do
+  if head -1 "$f" | grep -q 'bash'; then
+    bash_files="$bash_files $f"
+  fi
+done
+for f in $(find test -type f -name '*.sh' 2>/dev/null); do
+  if head -1 "$f" | grep -q 'bash'; then
+    bash_files="$bash_files $f"
+  fi
+done
+echo "Formatting:$bash_files"
+shfmt -w $bash_files
+"""
+
+[tasks.fmt-check]
+description = "Check formatting of all bash scripts"
+run = """
+bash_files=""
+for f in $(find bin -type f -name '*.sh' -o -type f ! -name '*.*'); do
+  if head -1 "$f" | grep -q 'bash'; then
+    bash_files="$bash_files $f"
+  fi
+done
+for f in $(find bin/lib -type f -name '*.sh' 2>/dev/null); do
+  if head -1 "$f" | grep -q 'bash'; then
+    bash_files="$bash_files $f"
+  fi
+done
+for f in $(find test -type f -name '*.sh' 2>/dev/null); do
+  if head -1 "$f" | grep -q 'bash'; then
+    bash_files="$bash_files $f"
+  fi
+done
+echo "Checking:$bash_files"
+shfmt -d $bash_files
+"""
+
 [tasks.check]
-description = "Run all checks (lint + test)"
-depends = ["lint", "test"]
+description = "Run all checks (lint + fmt-check + test)"
+depends = ["lint", "fmt-check", "test"]
 run = "echo 'All checks passed'"


### PR DESCRIPTION
## Summary

- Add `.shellcheckrc` (SC1091, SC2034 disabled)
- Add `.editorconfig` with `[*.sh]` section for shfmt settings
- Add `.github/workflows/check.yaml` (ShellCheck + shfmt + editorconfig-checker)
- Update `mise.toml` with `fmt`, `fmt-check`, and improved `lint`/`check` tasks
- Apply shfmt formatting to all 18 bash scripts

Part of org-wide P1 consistency pass.

## Test plan

- [ ] CI check.yaml workflow passes (ShellCheck, shfmt, editorconfig-checker)
- [ ] `mise run check` passes locally
- [ ] Existing test.yaml workflow still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)