### PR TITLE
feat(run-claude): show only updated plugins + 5-hour check cooldown

### DIFF
--- a/.ecrc
+++ b/.ecrc
@@ -1,0 +1,6 @@
+{
+  "Exclude": [
+    "docs/research/",
+    ".claude/tmp/"
+  ]
+}

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,6 +1,7 @@
 {
   "Exclude": [
     "docs/research/",
+    "docs/reports/",
     ".claude/tmp/"
   ]
 }

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup mise
+        uses: jdx/mise-action@v2
+
       - name: Find bash scripts
         id: find-bash
         run: |

--- a/bin/claude-diagnostics
+++ b/bin/claude-diagnostics
@@ -180,23 +180,33 @@ if [[ "$NO_USER" != "true" ]]; then
   mkdir -p "$USER_DIR/.claude" "$USER_DIR/.ai"
 
   if [[ "$NO_SETTINGS" != "true" ]]; then
-    copy_if_exists "$HOME/.claude/settings.json" "$USER_DIR/.claude/settings.json" && INCLUDED_CATEGORIES+=("user-settings") || true
+    if copy_if_exists "$HOME/.claude/settings.json" "$USER_DIR/.claude/settings.json"; then
+      INCLUDED_CATEGORIES+=("user-settings")
+    fi
     copy_if_exists "$HOME/.claude/settings.local.json" "$USER_DIR/.claude/settings.local.json" || true
   fi
 
-  copy_if_exists "$HOME/.claude/CLAUDE.md" "$USER_DIR/.claude/CLAUDE.md" && INCLUDED_CATEGORIES+=("user-claude-md") || true
+  if copy_if_exists "$HOME/.claude/CLAUDE.md" "$USER_DIR/.claude/CLAUDE.md"; then
+    INCLUDED_CATEGORIES+=("user-claude-md")
+  fi
 
   if [[ "$NO_RULES" != "true" ]]; then
-    copy_if_exists "$HOME/.claude/rules" "$USER_DIR/.claude/rules" && INCLUDED_CATEGORIES+=("user-rules") || true
+    if copy_if_exists "$HOME/.claude/rules" "$USER_DIR/.claude/rules"; then
+      INCLUDED_CATEGORIES+=("user-rules")
+    fi
     copy_if_exists "$HOME/.ai/rules" "$USER_DIR/.ai/rules" || true
   fi
 
   if [[ "$NO_COMMANDS" != "true" ]]; then
-    copy_if_exists "$HOME/.claude/commands" "$USER_DIR/.claude/commands" && INCLUDED_CATEGORIES+=("user-commands") || true
+    if copy_if_exists "$HOME/.claude/commands" "$USER_DIR/.claude/commands"; then
+      INCLUDED_CATEGORIES+=("user-commands")
+    fi
   fi
 
   if [[ "$NO_AGENTS" != "true" ]]; then
-    copy_if_exists "$HOME/.claude/agents" "$USER_DIR/.claude/agents" && INCLUDED_CATEGORIES+=("user-agents") || true
+    if copy_if_exists "$HOME/.claude/agents" "$USER_DIR/.claude/agents"; then
+      INCLUDED_CATEGORIES+=("user-agents")
+    fi
   fi
 
   # Remove empty directories
@@ -210,26 +220,36 @@ if [[ "$NO_PROJECT" != "true" ]]; then
   mkdir -p "$PROJECT_DIR/.claude" "$PROJECT_DIR/.ai"
 
   if [[ "$NO_SETTINGS" != "true" ]]; then
-    copy_if_exists "$CWD/.claude/settings.json" "$PROJECT_DIR/.claude/settings.json" && INCLUDED_CATEGORIES+=("project-settings") || true
+    if copy_if_exists "$CWD/.claude/settings.json" "$PROJECT_DIR/.claude/settings.json"; then
+      INCLUDED_CATEGORIES+=("project-settings")
+    fi
     copy_if_exists "$CWD/.claude/settings.local.json" "$PROJECT_DIR/.claude/settings.local.json" || true
   fi
 
-  copy_if_exists "$CWD/.claude/CLAUDE.md" "$PROJECT_DIR/.claude/CLAUDE.md" && INCLUDED_CATEGORIES+=("project-claude-md") || true
+  if copy_if_exists "$CWD/.claude/CLAUDE.md" "$PROJECT_DIR/.claude/CLAUDE.md"; then
+    INCLUDED_CATEGORIES+=("project-claude-md")
+  fi
   copy_if_exists "$CWD/AGENTS.md" "$PROJECT_DIR/AGENTS.md" || true
   copy_if_exists "$CWD/.ai/CLAUDE.md" "$PROJECT_DIR/.ai/CLAUDE.md" || true
 
   if [[ "$NO_RULES" != "true" ]]; then
-    copy_if_exists "$CWD/.claude/rules" "$PROJECT_DIR/.claude/rules" && INCLUDED_CATEGORIES+=("project-rules") || true
+    if copy_if_exists "$CWD/.claude/rules" "$PROJECT_DIR/.claude/rules"; then
+      INCLUDED_CATEGORIES+=("project-rules")
+    fi
     copy_if_exists "$CWD/.ai/rules" "$PROJECT_DIR/.ai/rules" || true
   fi
 
   if [[ "$NO_COMMANDS" != "true" ]]; then
-    copy_if_exists "$CWD/.claude/commands" "$PROJECT_DIR/.claude/commands" && INCLUDED_CATEGORIES+=("project-commands") || true
+    if copy_if_exists "$CWD/.claude/commands" "$PROJECT_DIR/.claude/commands"; then
+      INCLUDED_CATEGORIES+=("project-commands")
+    fi
     copy_if_exists "$CWD/.ai/commands" "$PROJECT_DIR/.ai/commands" || true
   fi
 
   if [[ "$NO_AGENTS" != "true" ]]; then
-    copy_if_exists "$CWD/.claude/agents" "$PROJECT_DIR/.claude/agents" && INCLUDED_CATEGORIES+=("project-agents") || true
+    if copy_if_exists "$CWD/.claude/agents" "$PROJECT_DIR/.claude/agents"; then
+      INCLUDED_CATEGORIES+=("project-agents")
+    fi
     copy_if_exists "$CWD/.ai/agents" "$PROJECT_DIR/.ai/agents" || true
   fi
 

--- a/bin/run-claude
+++ b/bin/run-claude
@@ -46,16 +46,47 @@ EOF
   fi
 fi
 
-# Update installed Claude Code plugins
-INSTALLED_PLUGINS_FILE="${CLAUDE_HOME:-$HOME/.claude}/plugins/installed_plugins.json"
-if [[ -f "$INSTALLED_PLUGINS_FILE" ]] && command -v jq &>/dev/null; then
+# Update installed Claude Code plugins (with 5-hour cooldown)
+CLAUDE_HOME="${CLAUDE_HOME:-$HOME/.claude}"
+INSTALLED_PLUGINS_FILE="$CLAUDE_HOME/plugins/installed_plugins.json"
+PLUGIN_CHECK_TIMESTAMP="$CLAUDE_HOME/.plugin-check-timestamp"
+PLUGIN_CHECK_COOLDOWN_SECONDS=$((5 * 60 * 60)) # 5 hours
+
+_plugin_check_needed() {
+  if [[ ! -f "$PLUGIN_CHECK_TIMESTAMP" ]]; then
+    return 0 # No timestamp — check needed
+  fi
+  local last_check now elapsed
+  last_check="$(cat "$PLUGIN_CHECK_TIMESTAMP")"
+  now="$(date +%s)"
+  elapsed=$((now - last_check))
+  if [[ $elapsed -ge $PLUGIN_CHECK_COOLDOWN_SECONDS ]]; then
+    return 0 # Cooldown expired
+  fi
+  return 1 # Still within cooldown
+}
+
+if [[ -f "$INSTALLED_PLUGINS_FILE" ]] && command -v jq &>/dev/null && _plugin_check_needed; then
   PLUGIN_NAMES="$(jq -r '.plugins | keys[]' "$INSTALLED_PLUGINS_FILE" 2>/dev/null)"
   if [[ -n "$PLUGIN_NAMES" ]]; then
-    echo "Checking for plugin updates..."
+    UPDATED_PLUGINS=()
     while IFS= read -r plugin; do
-      command claude plugin update "$plugin" 2>/dev/null || true
+      output="$(command claude plugin update "$plugin" 2>&1 || true)"
+      # Check if the output indicates an actual update (not "already up to date")
+      if [[ -n "$output" ]] && ! echo "$output" | grep -qi "already up.to.date\|no update\|up to date"; then
+        UPDATED_PLUGINS+=("$plugin")
+      fi
     done <<< "$PLUGIN_NAMES"
+
+    if [[ ${#UPDATED_PLUGINS[@]} -gt 0 ]]; then
+      echo "Updated plugins:"
+      for p in "${UPDATED_PLUGINS[@]}"; do
+        echo "  - $p"
+      done
+    fi
   fi
+  # Record check timestamp regardless of whether updates were found
+  date +%s > "$PLUGIN_CHECK_TIMESTAMP"
 fi
 
 claude_check_settings_backup

--- a/bin/run-claude
+++ b/bin/run-claude
@@ -76,7 +76,7 @@ if [[ -f "$INSTALLED_PLUGINS_FILE" ]] && command -v jq &>/dev/null && _plugin_ch
       if [[ -n "$output" ]] && ! echo "$output" | grep -qi "already up.to.date\|no update\|up to date"; then
         UPDATED_PLUGINS+=("$plugin")
       fi
-    done <<< "$PLUGIN_NAMES"
+    done <<<"$PLUGIN_NAMES"
 
     if [[ ${#UPDATED_PLUGINS[@]} -gt 0 ]]; then
       echo "Updated plugins:"
@@ -86,7 +86,7 @@ if [[ -f "$INSTALLED_PLUGINS_FILE" ]] && command -v jq &>/dev/null && _plugin_ch
     fi
   fi
   # Record check timestamp regardless of whether updates were found
-  date +%s > "$PLUGIN_CHECK_TIMESTAMP"
+  date +%s >"$PLUGIN_CHECK_TIMESTAMP"
 fi
 
 claude_check_settings_backup

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
 [tools]
 node = "lts"
 yarn = "4"
+shfmt = "latest"
 
 [tasks.test]
 description = "Run CLI tests"


### PR DESCRIPTION
## Summary

- **Plugin update cooldown**: Adds a 5-hour cooldown to plugin update checks in `run-claude`, using a timestamp file at `~/.claude/.plugin-check-timestamp`. Skips plugin updates if the last check was within the cooldown window.
- **Filtered plugin output**: Only prints plugins that were actually updated (filters out "already up to date" responses).
- **CI fixes**: Fixes pre-existing ShellCheck SC2015 violations in `claude-diagnostics`, adds shfmt to CI via mise, and configures editorconfig-checker exclusions for generated/research docs.

## Changes

- `bin/run-claude` — Plugin cooldown logic + filtered output
- `bin/claude-diagnostics` — SC2015 fixes (10 instances of `A && B || C` → proper `if`)
- `.github/workflows/check.yaml` — Added mise-action for shfmt
- `mise.toml` — Added shfmt tool
- `.editorconfig-checker.json` — Exclude docs/research/, docs/reports/, .claude/tmp/

## Test plan

- [ ] Run `run-claude` — verify plugin update check runs on first invocation
- [ ] Run `run-claude` again within 5 hours — verify plugin check is skipped
- [ ] Delete `~/.claude/.plugin-check-timestamp` — verify check runs again
- [ ] Verify `claude-diagnostics` still works end-to-end
- [ ] CI passes (shellcheck, shfmt, editorconfig-checker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)